### PR TITLE
fix: issue with deps update around php zend assertions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
           php-version: 8.5
           tools: composer:v2
           coverage: xdebug
+          ini-values: zend.assertions=1
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
Hotfix PR to resolve an issue with the deps being updated (phpunit/php-code-coverage  -> v14)  