### PR TITLE
fix: bump inertia to v3 from beta version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.5.0",
-        "inertiajs/inertia-laravel": "^3.0.0-beta",
+        "inertiajs/inertia-laravel": "^v3.0.6",
         "laravel/fortify": "^1.36.2",
         "laravel/framework": "^13.5.0",
         "laravel/wayfinder": "^0.1.16",


### PR DESCRIPTION
Fixes https://github.com/nunomaduro/laravel-starter-kit-inertia-react/issues/39

Bumps inertia from beta version to release v3 version