### PR TITLE
fix: passes canRegister prop to the login page

### DIFF
--- a/app/Http/Controllers/SessionController.php
+++ b/app/Http/Controllers/SessionController.php
@@ -18,6 +18,7 @@ final readonly class SessionController
     {
         return Inertia::render('session/Create', [
             'canResetPassword' => Route::has('password.request'),
+            'canRegister' => Route::has('register'),
             'status' => $request->session()->get('status'),
         ]);
     }

--- a/tests/Feature/Controllers/SessionControllerTest.php
+++ b/tests/Feature/Controllers/SessionControllerTest.php
@@ -15,6 +15,7 @@ it('renders login page', function (): void {
         ->assertInertia(fn ($page) => $page
             ->component('session/Create')
             ->has('canResetPassword')
+            ->has('canRegister')
             ->has('status'));
 });
 


### PR DESCRIPTION
## Problem

The login page (`resources/js/pages/session/Create.vue`) declares a `canRegister` prop and gates the "Sign up" link with `v-if="canRegister"`, but `SessionController@create` never passed it. The prop resolved to `undefined`, so the **"Sign up" link was never rendered** on the login page.

## Fix

Pass `canRegister` from the controller, mirroring the existing `canResetPassword` pattern:

```php
'canResetPassword' => Route::has('password.request'),
'canRegister' => Route::has('register'),
```

This keeps the link route-aware: if registration is disabled by removing the route, the link hides automatically.

## Tests

Extends the existing "renders login page" test to assert the prop is present. Full suite green (`composer test`).