### PR TITLE
fix: anchors ValidEmail regex to the full string

### DIFF
--- a/app/Rules/ValidEmail.php
+++ b/app/Rules/ValidEmail.php
@@ -10,7 +10,7 @@ use Illuminate\Translation\PotentiallyTranslatedString;
 
 final readonly class ValidEmail implements ValidationRule
 {
-    private const string REGEX = '/[a-z0-9!#$%&*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&*+\/=?^_`{|}~-]+)*@[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.[a-z]{2,}/';
+    private const string REGEX = '/^[a-z0-9!#$%&*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&*+\/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$/D';
 
     /**
      * Run the validation rule.

--- a/tests/Unit/Rules/ValidEmailTest.php
+++ b/tests/Unit/Rules/ValidEmailTest.php
@@ -116,4 +116,10 @@ it('fails with invalid email', function (string $email): void {
     'user@localdomain',
     'user@sub.-domain.com',
     '𝓊𝓃𝒾𝒸ℴ𝒹ℯ@𝒹ℴ𝓂𝒶𝒾𝓃.𝒸ℴ𝓂',
+
+    // Valid email embedded in surrounding text or with trailing data
+    'hello simple@example.com world',
+    'simple@example.com trailing',
+    'leading simple@example.com',
+    "simple@example.com\ninjected",
 ]);


### PR DESCRIPTION
## Problem

`App\Rules\ValidEmail`'s regex was **unanchored**, so `preg_match` matched a valid address as a *substring*. Values that merely *contain* an email passed validation:

```
'hello foo@bar.com world'   // passed (should fail)
"a@b.co\ninjected"          // passed (should fail)
```

## Fix

Anchor the pattern with `^...$` plus the `D` modifier so the whole string must be a valid email.

The domain section also changes from a single label to multi-label `(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}`. This is required: the previously-unanchored pattern only matched multi-subdomain hosts (`user@mail.example.com`, `user@example.co.uk`) by *ignoring* the trailing label, so anchoring alone would have regressed those valid addresses.

## Tests

Adds failing cases for embedded / trailing-data strings to the invalid dataset. All 68 `ValidEmail` cases pass; full suite green (`composer test`).