### PR TITLE
fix: rate-limits sensitive auth endpoints

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -21,12 +21,16 @@ Route::middleware(['auth', 'verified'])->group(function (): void {
 
 Route::middleware('auth')->group(function (): void {
     // User...
-    Route::delete('user', [UserController::class, 'destroy'])->name('user.destroy');
+    Route::delete('user', [UserController::class, 'destroy'])
+        ->middleware('throttle:6,1')
+        ->name('user.destroy');
 
     // User Profile...
     Route::redirect('settings', '/settings/profile');
     Route::get('settings/profile', [UserProfileController::class, 'edit'])->name('user-profile.edit');
-    Route::patch('settings/profile', [UserProfileController::class, 'update'])->name('user-profile.update');
+    Route::patch('settings/profile', [UserProfileController::class, 'update'])
+        ->middleware('throttle:6,1')
+        ->name('user-profile.update');
 
     // User Password...
     Route::get('settings/password', [UserPasswordController::class, 'edit'])->name('password.edit');
@@ -47,6 +51,7 @@ Route::middleware('guest')->group(function (): void {
     Route::get('register', [UserController::class, 'create'])
         ->name('register');
     Route::post('register', [UserController::class, 'store'])
+        ->middleware('throttle:6,1')
         ->name('register.store');
 
     // User Password...
@@ -59,6 +64,7 @@ Route::middleware('guest')->group(function (): void {
     Route::get('forgot-password', [UserEmailResetNotificationController::class, 'create'])
         ->name('password.request');
     Route::post('forgot-password', [UserEmailResetNotificationController::class, 'store'])
+        ->middleware('throttle:6,1')
         ->name('password.email');
 
     // Session...

--- a/tests/Feature/Controllers/UserControllerTest.php
+++ b/tests/Feature/Controllers/UserControllerTest.php
@@ -185,3 +185,29 @@ it('redirects authenticated users away from registration', function (): void {
 
     $response->assertRedirectToRoute('dashboard');
 });
+
+it('throttles registration attempts', function (): void {
+    foreach (range(1, 6) as $ignored) {
+        $this->postJson(route('register.store'), []);
+    }
+
+    $this->postJson(route('register.store'), [])->assertStatus(429);
+});
+
+it('throttles account deletion attempts', function (): void {
+    $user = User::factory()->create([
+        'password' => Hash::make('password'),
+    ]);
+
+    foreach (range(1, 6) as $ignored) {
+        $this->actingAs($user)->deleteJson(route('user.destroy'), [
+            'password' => 'wrong-password',
+        ]);
+    }
+
+    $this->actingAs($user)
+        ->deleteJson(route('user.destroy'), ['password' => 'wrong-password'])
+        ->assertStatus(429);
+
+    expect($user->fresh())->not->toBeNull();
+});

--- a/tests/Feature/Controllers/UserEmailResetNotificationTest.php
+++ b/tests/Feature/Controllers/UserEmailResetNotificationTest.php
@@ -66,6 +66,15 @@ it('requires valid email format', function (): void {
         ->assertSessionHasErrors('email');
 });
 
+it('throttles forgot-password requests', function (): void {
+    foreach (range(1, 6) as $ignored) {
+        $this->postJson(route('password.email'), ['email' => 'test@example.com']);
+    }
+
+    $this->postJson(route('password.email'), ['email' => 'test@example.com'])
+        ->assertStatus(429);
+});
+
 it('redirects authenticated users away from forgot password', function (): void {
     $user = User::factory()->create();
 

--- a/tests/Feature/Controllers/UserProfileControllerTest.php
+++ b/tests/Feature/Controllers/UserProfileControllerTest.php
@@ -145,3 +145,15 @@ it('allows keeping same email', function (): void {
     $response->assertRedirectToRoute('user-profile.edit')
         ->assertSessionDoesntHaveErrors();
 });
+
+it('throttles profile update requests', function (): void {
+    $user = User::factory()->create();
+
+    foreach (range(1, 6) as $ignored) {
+        $this->actingAs($user)->patchJson(route('user-profile.update'), []);
+    }
+
+    $this->actingAs($user)
+        ->patchJson(route('user-profile.update'), [])
+        ->assertStatus(429);
+});


### PR DESCRIPTION
## Problem

Several sensitive auth endpoints have no rate limiting, while their siblings do (`password.update` and the email-verification routes carry `throttle:6,1`), and the `web` middleware group has no global throttle:

- **`user.destroy` (DELETE /user)** — the sharpest: `DeleteUserRequest` gates deletion behind `current_password`, but the route is unthrottled. A hijacked session (stolen cookie) that doesn't know the password can brute-force `current_password` as an online oracle — and a correct guess also destroys the account. Its sibling `password.update`, which uses the same `current_password` rule, *is* throttled.
- **`register.store`** — unbounded mass account creation + verification-email dispatch.
- **`password.email` (forgot)** — mass reset-email dispatch (only the broker's per-email 60s throttle applies; no per-request/IP bound).
- **`user-profile.update`** — verification-email bombing via repeated email changes.

## Fix

Add `->middleware('throttle:6,1')` to those four routes, matching the convention already used by `password.update` and `verification.*`.

Intentionally **not** throttling `password.store` (reset completion): it already requires a valid 64-char reset token, which is infeasible to brute-force, so a rate limit adds little there.

## Tests

Adds a throttle-coverage test per route (7th request within the window returns 429). Full suite green: 164 tests, Pint, PHPStan max.